### PR TITLE
Fixes, `--platform` flag, and better tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ $ gh pin --dry-run
 
 ### Exit Codes
 
-- `0`: Success - all images processed successfully
-- `1`: Error - failed to process one or more files or images
+- `0`: Success - all resources processed successfully
+- `1`: Error - failed to process one or more resources
 
 ## How it Works 📚
 

--- a/cmd/gh-pin/main.go
+++ b/cmd/gh-pin/main.go
@@ -23,6 +23,7 @@ var (
 	algo           = flag.String("algo", "sha256", "digest algorithm to check for (sha256, sha512, etc.)")
 	forceMode      = flag.String("mode", "", "force processing mode: 'docker' for containers only, 'actions' for GitHub Actions only")
 	quiet          = flag.Bool("quiet", false, "suppress informational messages when no changes are needed")
+	platform       = flag.String("platform", "", "pin to platform-specific manifest digest (e.g., linux/amd64, linux/arm/v7)")
 )
 
 func main() {
@@ -40,12 +41,15 @@ func main() {
 	}
 
 	if len(flag.Args()) == 0 {
-		fmt.Fprintf(os.Stderr, "Usage: %s [--version] [--dry-run] [--no-color] [--recursive=false] [--pervasive] [--expand-registry] [--algo=sha256] [--mode=docker|actions] [--quiet] <file|dir> [file|dir...]\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "Usage: %s [--version] [--dry-run] [--no-color] [--recursive=false] [--pervasive] [--expand-registry] [--algo=sha256] [--mode=docker|actions] [--quiet] [--platform=linux/amd64] <file|dir> [file|dir...]\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, "\nSupported file types:\n")
 		fmt.Fprintf(os.Stderr, "  - Dockerfiles (FROM statements)\n")
 		fmt.Fprintf(os.Stderr, "  - Docker Compose files (image: fields)\n")
 		fmt.Fprintf(os.Stderr, "  - GitHub Actions workflows (uses: statements)\n")
 		fmt.Fprintf(os.Stderr, "  - Generic YAML files (with --pervasive flag)\n")
+		fmt.Fprintf(os.Stderr, "\nPlatform-specific pinning:\n")
+		fmt.Fprintf(os.Stderr, "  Use --platform=<arch> to pin to manifest-specific digests (e.g., linux/amd64, linux/arm/v7)\n")
+		fmt.Fprintf(os.Stderr, "  Without --platform, images are pinned to index digests with human-readable comments\n")
 		os.Exit(1)
 	}
 
@@ -58,6 +62,7 @@ func main() {
 		ExpandRegistry: *expandRegistry,
 		ForceMode:      *forceMode,
 		Quiet:          *quiet,
+		Platform:       *platform,
 		GitHubResolver: &processor.DefaultGitHubResolver{},
 	}
 

--- a/internal/processor/colors.go
+++ b/internal/processor/colors.go
@@ -10,7 +10,7 @@ import (
 // FormatDockerPin formats a Docker image pin message with granular coloring
 func FormatDockerPin(fileType, serviceName, originalImage, pinnedImage string) {
 	// Parse the original image to separate name and tag
-	imageName, imageTag := parseImageNameAndTag(originalImage)
+	imageName, imageTag := ParseImageNameAndTag(originalImage)
 
 	// Parse the pinned image to separate name and digest
 	pinnedName, pinnedDigest := parseImageNameAndDigest(pinnedImage)
@@ -59,8 +59,8 @@ func FormatActionPin(originalRef, pinnedRef string) {
 	}
 }
 
-// parseImageNameAndTag splits an image reference into name and tag
-func parseImageNameAndTag(image string) (name, tag string) {
+// ParseImageNameAndTag splits an image reference into name and tag
+func ParseImageNameAndTag(image string) (name, tag string) {
 	// Find the last colon that's not part of a digest
 	lastColon := -1
 	for i := len(image) - 1; i >= 0; i-- {

--- a/internal/processor/image.go
+++ b/internal/processor/image.go
@@ -3,9 +3,12 @@ package processor
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/regclient/regclient"
+	"github.com/regclient/regclient/types/manifest"
+	"github.com/regclient/regclient/types/platform"
 	"github.com/regclient/regclient/types/ref"
 )
 
@@ -16,18 +19,45 @@ func hasDigest(image, algorithm string) bool {
 
 // PinImage resolves an image tag to its immutable digest using regclient
 func PinImage(rc *regclient.RegClient, image string, config ProcessorConfig) (string, error) {
+	return PinImageWithComment(rc, image, config, true)
+}
+
+// PinImageWithComment resolves an image tag to its immutable digest using regclient
+// includeComment controls whether to add human-readable comments for index digests
+func PinImageWithComment(rc *regclient.RegClient, image string, config ProcessorConfig, includeComment bool) (string, error) {
 	r, err := ref.New(image)
 	if err != nil {
 		return "", fmt.Errorf("parse ref %q: %w", image, err)
 	}
 
 	ctx := context.Background()
-	m, err := rc.ManifestHead(ctx, r)
-	if err != nil {
-		return "", fmt.Errorf("fetch manifest for %q: %w", image, err)
+
+	// Store the original tag for human-readable comment
+	originalTag := r.Tag
+
+	var digest string
+	var usePlatformSpecific bool
+
+	// If platform is specified, try to get platform-specific manifest digest
+	if config.Platform != "" {
+		platformDigest, err := getPlatformSpecificDigest(ctx, rc, r, config.Platform)
+		if err != nil {
+			// Log warning and fall back to index digest
+			log.Printf("Warning: Could not find manifest for platform %s: %v. Falling back to index digest.", config.Platform, err)
+		} else {
+			digest = platformDigest
+			usePlatformSpecific = true
+		}
 	}
 
-	digest := m.GetDescriptor().Digest
+	// If no platform specified or platform-specific lookup failed, get index digest
+	if digest == "" {
+		m, err := rc.ManifestHead(ctx, r)
+		if err != nil {
+			return "", fmt.Errorf("fetch manifest for %q: %w", image, err)
+		}
+		digest = m.GetDescriptor().Digest.String()
+	}
 
 	// Use original reference format if ExpandRegistry is false, otherwise use CommonName
 	var imageRef string
@@ -43,5 +73,44 @@ func PinImage(rc *regclient.RegClient, image string, config ProcessorConfig) (st
 		imageRef = originalRef
 	}
 
-	return fmt.Sprintf("%s@%s", imageRef, digest.String()), nil
+	// Format the result based on whether we're using platform-specific or index digest
+	if usePlatformSpecific && originalTag != "" {
+		// For platform-specific manifests, use the full tag@digest format
+		return fmt.Sprintf("%s:%s@%s", imageRef, originalTag, digest), nil
+	} else {
+		// For index digests, use image@digest format with optional human-readable comment
+		result := fmt.Sprintf("%s@%s", imageRef, digest)
+		if originalTag != "" && includeComment {
+			result += fmt.Sprintf(" # pin@%s:%s", imageRef, originalTag)
+		}
+		return result, nil
+	}
+}
+
+// getPlatformSpecificDigest retrieves the digest for a specific platform manifest
+func getPlatformSpecificDigest(ctx context.Context, rc *regclient.RegClient, r ref.Ref, platformStr string) (string, error) {
+	// Parse the platform string
+	plat, err := platform.Parse(platformStr)
+	if err != nil {
+		return "", fmt.Errorf("invalid platform %q: %w", platformStr, err)
+	}
+
+	// Get the manifest list/index
+	m, err := rc.ManifestGet(ctx, r)
+	if err != nil {
+		return "", fmt.Errorf("fetch manifest for %q: %w", r.Reference, err)
+	}
+
+	// Check if it's a manifest list/index
+	if !m.IsList() {
+		return "", fmt.Errorf("image %q is not a multi-platform image", r.Reference)
+	}
+
+	// Find the platform-specific manifest
+	desc, err := manifest.GetPlatformDesc(m, &plat)
+	if err != nil {
+		return "", fmt.Errorf("platform %q not found in manifest list: %w", platformStr, err)
+	}
+
+	return desc.Digest.String(), nil
 }

--- a/internal/processor/types.go
+++ b/internal/processor/types.go
@@ -2,12 +2,8 @@ package processor
 
 import "os"
 
-// ComposeFile is a minimal representation of a docker-compose YAML
-type ComposeFile struct {
-	Services map[string]struct {
-		Image string `yaml:"image"`
-	} `yaml:"services"`
-}
+// ComposeFile is a flexible representation of a docker-compose YAML that preserves all fields
+type ComposeFile map[string]interface{}
 
 // ProcessorConfig holds configuration for the processor
 type ProcessorConfig struct {
@@ -18,6 +14,7 @@ type ProcessorConfig struct {
 	ExpandRegistry bool
 	ForceMode      string         // "docker", "actions", or "" for auto-detection
 	Quiet          bool           // suppress informational messages when no changes are needed
+	Platform       string         // platform-specific manifest digest (e.g., linux/amd64, linux/arm/v7)
 	GitHubResolver GitHubResolver // resolver for GitHub API calls (injected for testing)
 }
 

--- a/internal/processor/types_test.go
+++ b/internal/processor/types_test.go
@@ -89,21 +89,28 @@ func TestProcessorConfig(t *testing.T) {
 func TestComposeFile(t *testing.T) {
 	// Test ComposeFile struct creation and field access
 	cf := ComposeFile{
-		Services: map[string]struct {
-			Image string `yaml:"image"`
-		}{
-			"web": {Image: "nginx:latest"},
-			"db":  {Image: "postgres:13"},
+		"services": map[string]interface{}{
+			"web": map[string]interface{}{
+				"image": "nginx:latest",
+			},
+			"db": map[string]interface{}{
+				"image": "postgres:13",
+			},
 		},
 	}
 
-	if len(cf.Services) != 2 {
-		t.Errorf("Expected 2 services, got %d", len(cf.Services))
+	services := cf["services"].(map[string]interface{})
+	if len(services) != 2 {
+		t.Errorf("Expected 2 services, got %d", len(services))
 	}
-	if cf.Services["web"].Image != "nginx:latest" {
-		t.Errorf("Expected web service image to be 'nginx:latest', got %v", cf.Services["web"].Image)
+
+	webService := services["web"].(map[string]interface{})
+	if webService["image"] != "nginx:latest" {
+		t.Errorf("Expected web service image to be 'nginx:latest', got %v", webService["image"])
 	}
-	if cf.Services["db"].Image != "postgres:13" {
-		t.Errorf("Expected db service image to be 'postgres:13', got %v", cf.Services["db"].Image)
+
+	dbService := services["db"].(map[string]interface{})
+	if dbService["image"] != "postgres:13" {
+		t.Errorf("Expected db service image to be 'postgres:13', got %v", dbService["image"])
 	}
 }

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -53,8 +53,12 @@ func detectFileType(path string, data []byte, config processor.ProcessorConfig) 
 	if config.ForceMode == "docker" {
 		// Only allow docker-related types
 		var cf processor.ComposeFile
-		if err := yaml.Unmarshal(data, &cf); err == nil && len(cf.Services) > 0 {
-			return "compose"
+		if err := yaml.Unmarshal(data, &cf); err == nil {
+			if services, exists := cf["services"]; exists {
+				if servicesMap, ok := services.(map[string]interface{}); ok && len(servicesMap) > 0 {
+					return "compose"
+				}
+			}
 		}
 		return "unknown"
 	}
@@ -84,8 +88,12 @@ func detectFileType(path string, data []byte, config processor.ProcessorConfig) 
 
 	// Check if it's a Docker Compose file by structure
 	var cf processor.ComposeFile
-	if err := yaml.Unmarshal(data, &cf); err == nil && len(cf.Services) > 0 {
-		return "compose"
+	if err := yaml.Unmarshal(data, &cf); err == nil {
+		if services, exists := cf["services"]; exists {
+			if servicesMap, ok := services.(map[string]interface{}); ok && len(servicesMap) > 0 {
+				return "compose"
+			}
+		}
 	}
 
 	// Check if it contains GitHub Actions workflow structure

--- a/script/acceptance
+++ b/script/acceptance
@@ -162,4 +162,114 @@ fi
 
 echo -e "${GREEN}✅ PASS: Force mode flags work correctly${OFF}"
 
+# Test 7: Platform-specific pinning
+echo -e "${BLUE}Test 7: Platform-specific pinning functionality...${OFF}"
+
+# Create a test Dockerfile with multi-platform images
+mkdir -p "${TEMP_DIR}/platform-test"
+cat > "${TEMP_DIR}/platform-test/Dockerfile" << 'EOF'
+FROM nginx:latest
+FROM postgres:15
+EOF
+
+# Create a test Docker Compose file with multi-platform images
+cat > "${TEMP_DIR}/platform-test/docker-compose.yml" << 'EOF'
+version: '3.8'
+services:
+  web:
+    image: nginx:latest
+    ports:
+      - "80:80"
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: mydb
+EOF
+
+# Test platform-specific Dockerfile pinning in dry-run mode
+echo -e "${BLUE}Testing platform-specific Dockerfile pinning (linux/amd64)...${OFF}"
+dockerfile_output=$(go run -mod=vendor ./cmd/gh-pin --platform=linux/amd64 --dry-run "${TEMP_DIR}/platform-test/Dockerfile" 2>&1 || true)
+if [[ ! "$dockerfile_output" =~ "nginx:latest" ]] || [[ ! "$dockerfile_output" =~ "postgres:15" ]]; then
+    echo -e "${RED}❌ FAIL: Platform-specific Dockerfile pinning should process images${OFF}"
+    echo "Got output: $dockerfile_output"
+    exit 1
+fi
+
+# Verify platform-specific output format (should show clean format without comments)
+if [[ "$dockerfile_output" =~ "# pin@" ]]; then
+    echo -e "${RED}❌ FAIL: Platform-specific pinning should not show comments${OFF}"
+    echo "Got output: $dockerfile_output"
+    exit 1
+fi
+
+echo -e "${GREEN}✅ PASS: Platform-specific Dockerfile pinning works correctly${OFF}"
+
+# Test platform-specific Docker Compose pinning in dry-run mode
+echo -e "${BLUE}Testing platform-specific Docker Compose pinning (linux/arm64)...${OFF}"
+compose_output=$(go run -mod=vendor ./cmd/gh-pin --platform=linux/arm64 --dry-run "${TEMP_DIR}/platform-test/docker-compose.yml" 2>&1 || true)
+if [[ ! "$compose_output" =~ "Processing Compose" ]] || [[ ! "$compose_output" =~ "nginx:latest" ]] || [[ ! "$compose_output" =~ "postgres:15" ]]; then
+    echo -e "${RED}❌ FAIL: Platform-specific Compose pinning should process images${OFF}"
+    echo "Got output: $compose_output"
+    exit 1
+fi
+
+# Verify platform-specific compose output format (should show clean format without comments)
+if [[ "$compose_output" =~ "# pin@" ]]; then
+    echo -e "${RED}❌ FAIL: Platform-specific Compose pinning should not show comments${OFF}"
+    echo "Got output: $compose_output"
+    exit 1
+fi
+
+echo -e "${GREEN}✅ PASS: Platform-specific Docker Compose pinning works correctly${OFF}"
+
+# Test that different platforms may produce different digests
+echo -e "${BLUE}Testing platform specificity with different architectures...${OFF}"
+
+# Test with linux/amd64
+amd64_output=$(go run -mod=vendor ./cmd/gh-pin --platform=linux/amd64 --dry-run "${TEMP_DIR}/platform-test/Dockerfile" 2>&1 || true)
+# Test with linux/arm64  
+arm64_output=$(go run -mod=vendor ./cmd/gh-pin --platform=linux/arm64 --dry-run "${TEMP_DIR}/platform-test/Dockerfile" 2>&1 || true)
+
+# Both should work (though they might have same or different digests)
+if [[ ! "$amd64_output" =~ "nginx:latest" ]] || [[ ! "$arm64_output" =~ "nginx:latest" ]]; then
+    echo -e "${RED}❌ FAIL: Both platform tests should process nginx:latest${OFF}"
+    echo "AMD64 output: $amd64_output"
+    echo "ARM64 output: $arm64_output"
+    exit 1
+fi
+
+echo -e "${GREEN}✅ PASS: Multiple platform architectures work correctly${OFF}"
+
+# Test platform flag with invalid platform
+echo -e "${BLUE}Testing invalid platform handling...${OFF}"
+invalid_platform_output=$(go run -mod=vendor ./cmd/gh-pin --platform=invalid/platform --dry-run "${TEMP_DIR}/platform-test/Dockerfile" 2>&1 || true)
+if [[ ! "$invalid_platform_output" =~ "Warning: Could not find manifest for platform" ]] || [[ ! "$invalid_platform_output" =~ "Falling back" ]]; then
+    echo -e "${RED}❌ FAIL: Invalid platform should produce warning and fallback message${OFF}"
+    echo "Got output: $invalid_platform_output"
+    exit 1
+fi
+
+echo -e "${GREEN}✅ PASS: Invalid platform handling works correctly (graceful fallback)${OFF}"
+
+# Test default behavior (index digests) vs platform-specific behavior
+echo -e "${BLUE}Testing index digest vs platform-specific digest behavior...${OFF}"
+
+# Test default behavior (should show comments for index digests)
+default_output=$(go run -mod=vendor ./cmd/gh-pin --dry-run "${TEMP_DIR}/platform-test/docker-compose.yml" 2>&1 || true)
+if [[ ! "$default_output" =~ "# pin@" ]]; then
+    echo -e "${RED}❌ FAIL: Default behavior should show human-readable comments${OFF}"
+    echo "Got output: $default_output"
+    exit 1
+fi
+
+# Test platform-specific behavior (should not show comments)
+platform_output=$(go run -mod=vendor ./cmd/gh-pin --platform=linux/amd64 --dry-run "${TEMP_DIR}/platform-test/docker-compose.yml" 2>&1 || true)
+if [[ "$platform_output" =~ "# pin@" ]]; then
+    echo -e "${RED}❌ FAIL: Platform-specific behavior should not show comments${OFF}"
+    echo "Got output: $platform_output"
+    exit 1
+fi
+
+echo -e "${GREEN}✅ PASS: Index vs platform-specific behavior works correctly${OFF}"
+
 echo -e "${GREEN}🎉 All acceptance tests passed!${OFF}"


### PR DESCRIPTION
This pull request adds platform-specific image pinning support to the project, allowing users to resolve and pin container images to platform-specific manifest digests (e.g., `linux/amd64`, `linux/arm/v7`) via a new `--platform` flag. The changes ensure that when a platform is specified, images are pinned to the appropriate manifest digest without human-readable comments, and gracefully fall back to index digests if the platform is invalid or unavailable. The Docker Compose file handling is refactored to better preserve all fields and support more flexible structures. Comprehensive acceptance tests verify the new functionality.