### PR TITLE
Docker image format fixes

### DIFF
--- a/internal/processor/compose.go
+++ b/internal/processor/compose.go
@@ -44,8 +44,8 @@ func processComposeContent(rc *regclient.RegClient, data []byte, config Processo
 			suffix := match[3]   // " # some comment" or empty
 
 			if !hasDigest(imageRef, config.Algorithm) {
-				// Get pinned image - for compose files, we'll use the clean digest format
-				pinned, err := PinImageWithComment(rc, imageRef, config)
+				// Get pinned image using clean tag@digest format
+				pinned, err := PinImage(rc, imageRef, config)
 				if err != nil {
 					LogWarning("%v", err)
 					output.WriteString(line + "\n")

--- a/internal/processor/compose.go
+++ b/internal/processor/compose.go
@@ -3,7 +3,6 @@ package processor
 import (
 	"bufio"
 	"bytes"
-	"fmt"
 	"regexp"
 
 	"github.com/goccy/go-yaml"
@@ -46,36 +45,18 @@ func processComposeContent(rc *regclient.RegClient, data []byte, config Processo
 
 			if !hasDigest(imageRef, config.Algorithm) {
 				// Get pinned image - for compose files, we'll use the clean digest format
-				pinned, err := PinImageWithComment(rc, imageRef, config, false)
+				pinned, err := PinImageWithComment(rc, imageRef, config)
 				if err != nil {
 					LogWarning("%v", err)
 					output.WriteString(line + "\n")
 					continue
 				}
 				if pinned != "" {
-					// For console display
-					displayVersion := pinned
-					if config.Platform == "" {
-						// Only add comment for index digests, not platform-specific manifests
-						imageName, imageTag := ParseImageNameAndTag(imageRef)
-						if imageTag != "" {
-							displayVersion += fmt.Sprintf(" # pin@%s:%s", imageName, imageTag)
-						}
-					}
-					FormatDockerPin("COMPOSE", "", imageRef, displayVersion)
-
-					// For file content: add comment to pinned version unless suffix already has comments
-					fileVersion := pinned
-					if config.Platform == "" && suffix == "" {
-						// Only add comment for index digests and when no existing comment
-						imageName, imageTag := ParseImageNameAndTag(imageRef)
-						if imageTag != "" {
-							fileVersion += fmt.Sprintf(" # pin@%s:%s", imageName, imageTag)
-						}
-					}
+					// Use clean format for both console display and file content
+					FormatDockerPin("COMPOSE", "", imageRef, pinned)
 
 					// Preserve the original line structure, only replacing the image reference
-					newLine := prefix + fileVersion + suffix
+					newLine := prefix + pinned + suffix
 					output.WriteString(newLine + "\n")
 					changed = true
 					continue

--- a/internal/processor/image.go
+++ b/internal/processor/image.go
@@ -19,12 +19,12 @@ func hasDigest(image, algorithm string) bool {
 
 // PinImage resolves an image tag to its immutable digest using regclient
 func PinImage(rc *regclient.RegClient, image string, config ProcessorConfig) (string, error) {
-	return PinImageWithComment(rc, image, config, true)
+	return PinImageWithComment(rc, image, config)
 }
 
 // PinImageWithComment resolves an image tag to its immutable digest using regclient
-// includeComment controls whether to add human-readable comments for index digests
-func PinImageWithComment(rc *regclient.RegClient, image string, config ProcessorConfig, includeComment bool) (string, error) {
+// Always returns clean tag@digest format for better Docker compatibility
+func PinImageWithComment(rc *regclient.RegClient, image string, config ProcessorConfig) (string, error) {
 	r, err := ref.New(image)
 	if err != nil {
 		return "", fmt.Errorf("parse ref %q: %w", image, err)
@@ -32,11 +32,7 @@ func PinImageWithComment(rc *regclient.RegClient, image string, config Processor
 
 	ctx := context.Background()
 
-	// Store the original tag for human-readable comment
-	originalTag := r.Tag
-
 	var digest string
-	var usePlatformSpecific bool
 
 	// If platform is specified, try to get platform-specific manifest digest
 	if config.Platform != "" {
@@ -46,7 +42,6 @@ func PinImageWithComment(rc *regclient.RegClient, image string, config Processor
 			log.Printf("Warning: Could not find manifest for platform %s: %v. Falling back to index digest.", config.Platform, err)
 		} else {
 			digest = platformDigest
-			usePlatformSpecific = true
 		}
 	}
 
@@ -64,27 +59,17 @@ func PinImageWithComment(rc *regclient.RegClient, image string, config Processor
 	if config.ExpandRegistry {
 		imageRef = r.CommonName()
 	} else {
-		// Use the original reference, but we need to strip the tag if present
-		// since we're adding the digest
-		originalRef := r.Reference
-		if idx := strings.LastIndex(originalRef, ":"); idx != -1 && !strings.Contains(originalRef[idx:], "@") {
-			originalRef = originalRef[:idx]
+		// For both index and platform-specific digests, preserve the original tag
+		// This gives us a cleaner format like ruby:3.4.4-slim@sha256:hash
+		imageRef = r.Reference
+		// Strip existing digest if present (shouldn't happen with unpinned images)
+		if idx := strings.LastIndex(imageRef, "@"); idx != -1 {
+			imageRef = imageRef[:idx]
 		}
-		imageRef = originalRef
 	}
 
-	// Format the result based on whether we're using platform-specific or index digest
-	if usePlatformSpecific && originalTag != "" {
-		// For platform-specific manifests, use the full tag@digest format
-		return fmt.Sprintf("%s:%s@%s", imageRef, originalTag, digest), nil
-	} else {
-		// For index digests, use image@digest format with optional human-readable comment
-		result := fmt.Sprintf("%s@%s", imageRef, digest)
-		if originalTag != "" && includeComment {
-			result += fmt.Sprintf(" # pin@%s:%s", imageRef, originalTag)
-		}
-		return result, nil
-	}
+	// Use the clean tag@digest format for both index and platform-specific digests
+	return fmt.Sprintf("%s@%s", imageRef, digest), nil
 }
 
 // getPlatformSpecificDigest retrieves the digest for a specific platform manifest

--- a/internal/processor/image.go
+++ b/internal/processor/image.go
@@ -18,13 +18,8 @@ func hasDigest(image, algorithm string) bool {
 }
 
 // PinImage resolves an image tag to its immutable digest using regclient
+// Returns clean tag@digest format for better Docker compatibility
 func PinImage(rc *regclient.RegClient, image string, config ProcessorConfig) (string, error) {
-	return PinImageWithComment(rc, image, config)
-}
-
-// PinImageWithComment resolves an image tag to its immutable digest using regclient
-// Always returns clean tag@digest format for better Docker compatibility
-func PinImageWithComment(rc *regclient.RegClient, image string, config ProcessorConfig) (string, error) {
 	r, err := ref.New(image)
 	if err != nil {
 		return "", fmt.Errorf("parse ref %q: %w", image, err)

--- a/script/acceptance
+++ b/script/acceptance
@@ -43,14 +43,14 @@ echo -e "${BLUE}Running gh-pin on test Dockerfile...${OFF}"
 go run -mod=vendor ./cmd/gh-pin "${TEMP_DIR}/Dockerfile"
 
 # Verify the file now contains SHA digests
-if ! grep -q "FROM ubuntu@sha256:" "${TEMP_DIR}/Dockerfile"; then
+if ! grep -q "FROM ubuntu:latest@sha256:" "${TEMP_DIR}/Dockerfile"; then
     echo -e "${RED}❌ FAIL: ubuntu:latest was not pinned to SHA digest${OFF}"
     echo "File contents:"
     cat "${TEMP_DIR}/Dockerfile"
     exit 1
 fi
 
-if ! grep -q "FROM alpine@sha256:" "${TEMP_DIR}/Dockerfile"; then
+if ! grep -q "FROM alpine:3.18@sha256:" "${TEMP_DIR}/Dockerfile"; then
     echo -e "${RED}❌ FAIL: alpine:3.18 was not pinned to SHA digest${OFF}"
     echo "File contents:"
     cat "${TEMP_DIR}/Dockerfile"
@@ -94,7 +94,7 @@ echo -e "${BLUE}Test 4: Algorithm flag functionality...${OFF}"
 
 # Create a test file with a sha256-pinned image
 mkdir -p "${TEMP_DIR}/algo-test"
-echo "FROM ubuntu@sha256:7c06e91f61fa88c08cc74f7e1b7c69ae24910d745357e0dfe1d2c0322aaf20f9" > "${TEMP_DIR}/algo-test/Dockerfile"
+echo "FROM ubuntu:latest@sha256:7c06e91f61fa88c08cc74f7e1b7c69ae24910d745357e0dfe1d2c0322aaf20f9" > "${TEMP_DIR}/algo-test/Dockerfile"
 
 # Test default behavior (should skip sha256-pinned image)
 output=$(go run -mod=vendor ./cmd/gh-pin --dry-run --quiet "${TEMP_DIR}/algo-test/Dockerfile" 2>&1 || true)
@@ -254,18 +254,18 @@ echo -e "${GREEN}✅ PASS: Invalid platform handling works correctly (graceful f
 # Test default behavior (index digests) vs platform-specific behavior
 echo -e "${BLUE}Testing index digest vs platform-specific digest behavior...${OFF}"
 
-# Test default behavior (should show comments for index digests)
+# Test default behavior (should show clean tag@digest format)
 default_output=$(go run -mod=vendor ./cmd/gh-pin --dry-run "${TEMP_DIR}/platform-test/docker-compose.yml" 2>&1 || true)
-if [[ ! "$default_output" =~ "# pin@" ]]; then
-    echo -e "${RED}❌ FAIL: Default behavior should show human-readable comments${OFF}"
+if [[ ! "$default_output" =~ "nginx:latest@sha256:" ]]; then
+    echo -e "${RED}❌ FAIL: Default behavior should show clean tag@digest format${OFF}"
     echo "Got output: $default_output"
     exit 1
 fi
 
-# Test platform-specific behavior (should not show comments)
+# Test platform-specific behavior (should also show clean format)
 platform_output=$(go run -mod=vendor ./cmd/gh-pin --platform=linux/amd64 --dry-run "${TEMP_DIR}/platform-test/docker-compose.yml" 2>&1 || true)
-if [[ "$platform_output" =~ "# pin@" ]]; then
-    echo -e "${RED}❌ FAIL: Platform-specific behavior should not show comments${OFF}"
+if [[ ! "$platform_output" =~ "nginx:latest@sha256:" ]]; then
+    echo -e "${RED}❌ FAIL: Platform-specific behavior should show clean tag@digest format${OFF}"
     echo "Got output: $platform_output"
     exit 1
 fi


### PR DESCRIPTION
Refactor image pinning logic to use clean tag@digest format and update acceptance tests accordingly