### PR TITLE
Add path completion support

### DIFF
--- a/cmd/gh-pin/completion.go
+++ b/cmd/gh-pin/completion.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func isCompletionRequest(args []string) bool {
+	if len(args) == 0 {
+		return false
+	}
+	return args[0] == "__complete" || args[0] == "__completeNoDesc"
+}
+
+type completionItem struct {
+	value       string
+	description string
+}
+
+const (
+	shellCompDirectiveDefault    = 0
+	shellCompDirectiveNoSpace    = 2
+	shellCompDirectiveNoFileComp = 4
+)
+
+var flagCompletionItems = []completionItem{
+	{value: "--no-color", description: "disable colored output"},
+	{value: "--dry-run", description: "preview changes without writing files"},
+	{value: "--recursive", description: "scan directories recursively"},
+	{value: "--pervasive", description: "scan all YAML files"},
+	{value: "--expand-registry", description: "expand short image names"},
+	{value: "--version", description: "show version information"},
+	{value: "--algo", description: "digest algorithm"},
+	{value: "--mode", description: "force processing mode"},
+	{value: "--quiet", description: "suppress no-change messages"},
+	{value: "--platform", description: "platform-specific manifest digest"},
+}
+
+func (r commandRunner) complete(noDescriptions bool, args []string, stdout io.Writer) int {
+	completions, directive := r.completionResults(args)
+	for _, completion := range completions {
+		if noDescriptions || completion.description == "" {
+			fmt.Fprintln(stdout, completion.value)
+			continue
+		}
+		fmt.Fprintf(stdout, "%s\t%s\n", completion.value, completion.description)
+	}
+	fmt.Fprintf(stdout, ":%d\n", directive)
+	return 0
+}
+
+func (r commandRunner) completionResults(args []string) ([]completionItem, int) {
+	current := ""
+	if len(args) > 0 {
+		current = args[len(args)-1]
+	}
+
+	if completions, ok := completeFlagValue(args); ok {
+		return completions, shellCompDirectiveNoFileComp
+	}
+
+	if strings.HasPrefix(current, "-") {
+		return completeFlags(current), shellCompDirectiveNoFileComp
+	}
+
+	return r.completePath(current)
+}
+
+func completeFlagValue(args []string) ([]completionItem, bool) {
+	if len(args) == 0 {
+		return nil, false
+	}
+
+	current := args[len(args)-1]
+	if flagName, prefix, ok := strings.Cut(current, "="); ok {
+		values, found := flagValueCompletions(flagName)
+		if !found {
+			return nil, false
+		}
+		return filterCompletionItems(values, prefix), true
+	}
+
+	if len(args) < 2 {
+		return nil, false
+	}
+	values, found := separateFlagValueCompletions(args[len(args)-2])
+	if !found {
+		return nil, false
+	}
+	return filterCompletionItems(values, current), true
+}
+
+func separateFlagValueCompletions(flagName string) ([]completionItem, bool) {
+	switch flagName {
+	case "--algo", "--mode", "--platform":
+		return flagValueCompletions(flagName)
+	default:
+		return nil, false
+	}
+}
+
+func flagValueCompletions(flagName string) ([]completionItem, bool) {
+	switch flagName {
+	case "--recursive":
+		return []completionItem{
+			{value: "true", description: "scan nested directories"},
+			{value: "false", description: "scan only the selected directory"},
+		}, true
+	case "--algo":
+		return []completionItem{
+			{value: "sha256", description: "standard OCI digest algorithm"},
+			{value: "sha512", description: "alternate digest algorithm"},
+		}, true
+	case "--mode":
+		return []completionItem{
+			{value: "docker", description: "pin container image references only"},
+			{value: "actions", description: "pin GitHub Actions references only"},
+		}, true
+	case "--platform":
+		return []completionItem{
+			{value: "linux/amd64", description: "Linux AMD64 manifest"},
+			{value: "linux/arm64", description: "Linux ARM64 manifest"},
+			{value: "linux/arm/v7", description: "Linux ARMv7 manifest"},
+		}, true
+	default:
+		return nil, false
+	}
+}
+
+func completeFlags(prefix string) []completionItem {
+	return filterCompletionItems(flagCompletionItems, prefix)
+}
+
+func filterCompletionItems(items []completionItem, prefix string) []completionItem {
+	var completions []completionItem
+	for _, item := range items {
+		if strings.HasPrefix(item.value, prefix) {
+			completions = append(completions, item)
+		}
+	}
+	return completions
+}
+
+func (r commandRunner) completePath(prefix string) ([]completionItem, int) {
+	dir, namePrefix := filepath.Split(prefix)
+	readDir := dir
+	if readDir == "" {
+		readDir = "."
+	}
+
+	entries, err := r.readDir(readDir)
+	if err != nil {
+		return nil, shellCompDirectiveDefault
+	}
+
+	includeHidden := strings.HasPrefix(namePrefix, ".")
+	var completions []completionItem
+	dirCount := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if namePrefix == "" && strings.HasPrefix(name, ".") && !includeHidden {
+			continue
+		}
+		if !strings.HasPrefix(name, namePrefix) {
+			continue
+		}
+
+		value := dir + name
+		if entry.IsDir() {
+			value += string(os.PathSeparator)
+			dirCount++
+		}
+		completions = append(completions, completionItem{value: value})
+	}
+
+	if len(completions) > 0 && dirCount == len(completions) {
+		return completions, shellCompDirectiveNoSpace
+	}
+	return completions, shellCompDirectiveDefault
+}

--- a/cmd/gh-pin/completion_test.go
+++ b/cmd/gh-pin/completion_test.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCommandRunnerCompletionCompletesCurrentDirectoryPaths(t *testing.T) {
+	tempDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tempDir, ".github", "workflows"), 0755); err != nil {
+		t.Fatalf("mkdir workflows: %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(tempDir, "docs"), 0755); err != nil {
+		t.Fatalf("mkdir docs: %v", err)
+	}
+	for _, file := range []string{
+		filepath.Join(tempDir, ".github", "workflows", "ci.yml"),
+		filepath.Join(tempDir, ".github", "workflows", "release.yml"),
+		filepath.Join(tempDir, "Dockerfile"),
+		filepath.Join(tempDir, ".env"),
+	} {
+		if err := os.WriteFile(file, []byte("test"), 0644); err != nil {
+			t.Fatalf("write %s: %v", file, err)
+		}
+	}
+	t.Chdir(tempDir)
+
+	tests := []struct {
+		name      string
+		args      []string
+		want      []string
+		notWant   []string
+		directive string
+	}{
+		{
+			name:      "hidden directory after dot prefix",
+			args:      []string{"__complete", ".g"},
+			want:      []string{".github/"},
+			directive: ":2",
+		},
+		{
+			name:      "nested directory",
+			args:      []string{"__complete", ".github/w"},
+			want:      []string{".github/workflows/"},
+			directive: ":2",
+		},
+		{
+			name:      "nested workflow files",
+			args:      []string{"__complete", ".github/workflows/"},
+			want:      []string{".github/workflows/ci.yml", ".github/workflows/release.yml"},
+			directive: ":0",
+		},
+		{
+			name:      "empty prefix hides dotfiles like shell completion",
+			args:      []string{"__complete", ""},
+			want:      []string{"Dockerfile", "docs/"},
+			notWant:   []string{".github/", ".env"},
+			directive: ":0",
+		},
+		{
+			name:      "missing path falls back to shell file completion",
+			args:      []string{"__complete", "missing/path"},
+			directive: ":0",
+		},
+	}
+
+	runner := defaultCommandRunner()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+
+			code := runner.run("gh-pin", tt.args, &stdout, &stderr)
+
+			if code != 0 {
+				t.Fatalf("run() exit code = %d, want 0; stderr=%q", code, stderr.String())
+			}
+			if stderr.Len() != 0 {
+				t.Fatalf("stderr = %q, want empty", stderr.String())
+			}
+			got := strings.TrimSpace(stdout.String())
+			for _, want := range tt.want {
+				if !completionOutputContains(got, want) {
+					t.Fatalf("completion output = %q, want %q", got, want)
+				}
+			}
+			for _, notWant := range tt.notWant {
+				if completionOutputContains(got, notWant) {
+					t.Fatalf("completion output = %q, did not want %q", got, notWant)
+				}
+			}
+			if !strings.HasSuffix(got, tt.directive) {
+				t.Fatalf("completion output = %q, want directive %q", got, tt.directive)
+			}
+		})
+	}
+}
+
+func TestCommandRunnerCompletionCompletesFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		want    []string
+		notWant []string
+	}{
+		{
+			name: "flag names with descriptions",
+			args: []string{"__complete", "--d"},
+			want: []string{"--dry-run\tpreview changes without writing files", ":4"},
+		},
+		{
+			name:    "flag names without descriptions",
+			args:    []string{"__completeNoDesc", "--d"},
+			want:    []string{"--dry-run", ":4"},
+			notWant: []string{"\tpreview changes without writing files"},
+		},
+		{
+			name: "mode value",
+			args: []string{"__complete", "--mode", "d"},
+			want: []string{"docker\tpin container image references only", ":4"},
+		},
+		{
+			name: "platform equals value",
+			args: []string{"__complete", "--platform=linux/a"},
+			want: []string{"linux/amd64\tLinux AMD64 manifest", "linux/arm64\tLinux ARM64 manifest", ":4"},
+		},
+		{
+			name:    "recursive bool value only completes with equals",
+			args:    []string{"__complete", "--recursive", ""},
+			notWant: []string{"true\tscan nested directories", "false\tscan only the selected directory"},
+		},
+		{
+			name: "recursive equals value",
+			args: []string{"__complete", "--recursive=f"},
+			want: []string{"false\tscan only the selected directory", ":4"},
+		},
+	}
+
+	runner := defaultCommandRunner()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+
+			code := runner.run("gh-pin", tt.args, &stdout, &stderr)
+
+			if code != 0 {
+				t.Fatalf("run() exit code = %d, want 0; stderr=%q", code, stderr.String())
+			}
+			got := strings.TrimSpace(stdout.String())
+			for _, want := range tt.want {
+				if !completionOutputContains(got, want) {
+					t.Fatalf("completion output = %q, want %q", got, want)
+				}
+			}
+			for _, notWant := range tt.notWant {
+				if strings.Contains(got, notWant) {
+					t.Fatalf("completion output = %q, did not want %q", got, notWant)
+				}
+			}
+		})
+	}
+}
+
+func completionOutputContains(output, want string) bool {
+	for _, line := range strings.Split(output, "\n") {
+		if line == want {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/gh-pin/main.go
+++ b/cmd/gh-pin/main.go
@@ -17,6 +17,7 @@ import (
 
 type commandRunner struct {
 	stat                  func(string) (os.FileInfo, error)
+	readDir               func(string) ([]os.DirEntry, error)
 	newRegClient          func() *regclient.RegClient
 	scanPath              func(*regclient.RegClient, string, processor.ProcessorConfig, bool) error
 	processSingleFile     func(*regclient.RegClient, string, processor.ProcessorConfig) error
@@ -35,6 +36,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 func defaultCommandRunner() commandRunner {
 	return commandRunner{
 		stat:                  os.Stat,
+		readDir:               os.ReadDir,
 		newRegClient:          newRegClientFromEnv,
 		scanPath:              scanner.ScanPath,
 		processSingleFile:     scanner.ProcessSingleFile,
@@ -44,6 +46,10 @@ func defaultCommandRunner() commandRunner {
 }
 
 func (r commandRunner) run(programName string, args []string, stdout, stderr io.Writer) int {
+	if isCompletionRequest(args) {
+		return r.complete(args[0] == "__completeNoDesc", args[1:], stdout)
+	}
+
 	flags := flag.NewFlagSet(programName, flag.ContinueOnError)
 	flags.SetOutput(stderr)
 

--- a/cmd/gh-pin/main_test.go
+++ b/cmd/gh-pin/main_test.go
@@ -288,6 +288,7 @@ func defaultTestRunner(files map[string]fakeFileInfo) commandRunner {
 			}
 			return info, nil
 		},
+		readDir: os.ReadDir,
 		newRegClient: func() *regclient.RegClient {
 			return nil
 		},


### PR DESCRIPTION
## Summary

Adds native `__complete` / `__completeNoDesc` handling so `gh pin` can answer shell completion probes with current-directory path candidates, flag names, and supported flag values instead of treating `__complete` as an input path.

Validated with `script/lint`, `script/test`, `script/build --single-target`, and the fully offline `script/acceptance` suite.
