### PR TITLE
Filter git metadata from path completions

### DIFF
--- a/cmd/gh-pin/completion.go
+++ b/cmd/gh-pin/completion.go
@@ -161,6 +161,9 @@ func (r commandRunner) completePath(prefix string) ([]completionItem, int) {
 	dirCount := 0
 	for _, entry := range entries {
 		name := entry.Name()
+		if skipPathCompletionEntry(name) {
+			continue
+		}
 		if namePrefix == "" && strings.HasPrefix(name, ".") && !includeHidden {
 			continue
 		}
@@ -180,4 +183,13 @@ func (r commandRunner) completePath(prefix string) ([]completionItem, int) {
 		return completions, shellCompDirectiveNoSpace
 	}
 	return completions, shellCompDirectiveDefault
+}
+
+func skipPathCompletionEntry(name string) bool {
+	switch name {
+	case ".git", ".gitattributes", ".gitignore", ".gitmodules":
+		return true
+	default:
+		return false
+	}
 }

--- a/cmd/gh-pin/completion_test.go
+++ b/cmd/gh-pin/completion_test.go
@@ -16,11 +16,16 @@ func TestCommandRunnerCompletionCompletesCurrentDirectoryPaths(t *testing.T) {
 	if err := os.Mkdir(filepath.Join(tempDir, "docs"), 0755); err != nil {
 		t.Fatalf("mkdir docs: %v", err)
 	}
+	if err := os.Mkdir(filepath.Join(tempDir, ".git"), 0755); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
 	for _, file := range []string{
 		filepath.Join(tempDir, ".github", "workflows", "ci.yml"),
 		filepath.Join(tempDir, ".github", "workflows", "release.yml"),
 		filepath.Join(tempDir, "Dockerfile"),
 		filepath.Join(tempDir, ".env"),
+		filepath.Join(tempDir, ".gitattributes"),
+		filepath.Join(tempDir, ".gitignore"),
 	} {
 		if err := os.WriteFile(file, []byte("test"), 0644); err != nil {
 			t.Fatalf("write %s: %v", file, err)
@@ -39,6 +44,7 @@ func TestCommandRunnerCompletionCompletesCurrentDirectoryPaths(t *testing.T) {
 			name:      "hidden directory after dot prefix",
 			args:      []string{"__complete", ".g"},
 			want:      []string{".github/"},
+			notWant:   []string{".git/", ".gitattributes", ".gitignore"},
 			directive: ":2",
 		},
 		{


### PR DESCRIPTION
## Summary

Filters Git metadata paths like `.git/`, `.gitignore`, `.gitattributes`, and `.gitmodules` out of `gh pin` path completions so `.gi<TAB>` can resolve directly toward `.github/`.

Validated with `script/lint`, `script/test`, `script/build --single-target`, and `script/acceptance`.
