### PR TITLE
Harden dependency automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,20 +1,29 @@
+---
 version: 2
-
 updates:
-  - package-ecosystem: gomod
-    directory: "/"
-    schedule:
-      interval: monthly
-    groups:
-      go-dependencies:
-        patterns:
-          - "*"
-
-  - package-ecosystem: github-actions
-    directory: "/"
-    groups:
-      github-actions:
-        patterns:
-          - "*"
-    schedule:
-      interval: monthly
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: monthly
+  groups:
+    go-dependencies:
+      patterns:
+      - "*"
+  cooldown:
+    default-days: 45
+- package-ecosystem: github-actions
+  directory: "/"
+  groups:
+    github-actions:
+      patterns:
+      - "*"
+  schedule:
+    interval: monthly
+  cooldown:
+    default-days: 45
+- package-ecosystem: docker-compose
+  directory: "/test/fixtures"
+  schedule:
+    interval: monthly
+  cooldown:
+    default-days: 45

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
         with:
           persist-credentials: false
 
       - name: setup go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # pin@v6
         with:
           go-version-file: 'go.mod'
           cache: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
         with:
           persist-credentials: false
 
       - name: setup go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # pin@v6
         with:
           go-version-file: 'go.mod'
           cache: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
         with:
           persist-credentials: false
 
       - name: setup go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # pin@v6
         with:
           go-version-file: 'go.mod'
           cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -38,7 +38,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: upload artifact
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # pin@v7.0.0
         id: upload-artifact
         with:
           name: dist
@@ -54,13 +54,13 @@ jobs:
       attestations: write
       contents: read
     steps:
-      - uses: actions/download-artifact@v8.0.0
+      - uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # pin@v8.0.0
         with:
           artifact-ids: ${{ needs.release.outputs.artifact-id }}
           path: "dist/"
 
       - name: attest build provenance
-        uses: actions/attest-build-provenance@v4.1.0
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # pin@v4.1.0
         with:
           subject-path: "dist/"
 
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [release, sign]
     steps:
-      - uses: actions/download-artifact@v8.0.0
+      - uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # pin@v8.0.0
         with:
           artifact-ids: ${{ needs.release.outputs.artifact-id }}
           path: "dist/"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
         with:
           persist-credentials: false
 
       - name: setup go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # pin@v6
         with:
           go-version-file: 'go.mod'
           cache: true


### PR DESCRIPTION
This pins mutable GitHub Actions references where needed and adds 45-day Dependabot cooldowns for configured dependency ecosystems.